### PR TITLE
Create pokemon-berry table

### DIFF
--- a/docs/tables/pokemon_berry.md
+++ b/docs/tables/pokemon_berry.md
@@ -1,0 +1,47 @@
+# Table: pokemon_berry
+
+Berries (Japanese: きのみ Tree Fruit) are small, juicy, fleshy fruit. As in the real world, a large variety exists in the Pokémon world, with a large range of flavors, names, and effects. First found in the Generation II games, many Berries have since become critical held items in battle, where their various effects include HP and status condition restoration, stat enhancement, and even damage negation.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  id, 
+  growth_time,
+  max_harvest,
+  natural_gift_power,
+  size,
+  smoothness,
+  soil_dryness
+from 
+  pokemon_berry
+```
+
+### List all Berry where size more than 100 mm
+
+```sql
+select
+  name,
+  id,
+  size
+from
+  pokemon_berry
+where
+  size > 100
+```
+
+### List all Berry where soil_dryness between 10 and 30
+
+```sql
+select
+  name,
+  id,
+  soil_dryness
+from
+  pokemon_berry
+where 
+  soil_dryness between 10 and 30
+```

--- a/pokemon/plugin.go
+++ b/pokemon/plugin.go
@@ -12,6 +12,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 		Name:             "steampipe-plugin-pokemon",
 		DefaultTransform: transform.FromCamel(),
 		TableMap: map[string]*plugin.Table{
+			"pokemon_berry": tablePokemonBerry(ctx),
 			"pokemon_pokemon": tablePokemonPokemon(ctx),
 		},
 	}

--- a/pokemon/table_pokemon_berry.go
+++ b/pokemon/table_pokemon_berry.go
@@ -1,0 +1,173 @@
+package pokemon
+
+import (
+	"context"
+
+	"github.com/mtslzr/pokeapi-go"
+	"github.com/mtslzr/pokeapi-go/structs"
+
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+)
+
+func tablePokemonBerry(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "pokemon_berry",
+		Description: "Berries are small fruits that can provide HP and status condition restoration, stat enhancement, and even damage negation when eaten by Pokémon.",
+		List: &plugin.ListConfig{
+			Hydrate: listBerry,
+		},
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AnyColumn([]string{"name"}),
+			// TODO: Add support for 'id' key column
+			// KeyColumns: plugin.AnyColumn([]string{"id", "name"}),
+			Hydrate: getBerry,
+			// Bad error message is a result of https://github.com/mtslzr/pokeapi-go/issues/29
+			ShouldIgnoreError: isNotFoundError([]string{"invalid character 'N' looking for beginning of value"}),
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "name",
+				Description: "The name for this resource.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "firmness",
+				Description: "The firmness of this berry, used in making Pokéblocks or Poffins.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getBerry,
+			},
+			{
+				Name:        "flavors",
+				Description: "A list of references to each flavor a berry can have and the potency of each of those flavors in regard to this berry.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getBerry,
+			},
+			{
+				Name:        "growth_time",
+				Description: "Time it takes the tree to grow one stage, in hours. Berry trees go through four of these growth stages before they can be picked.",
+				Type:        proto.ColumnType_INT,
+				Hydrate:     getBerry,
+			},
+			{
+				Name:        "id",
+				Description: "The identifier for this resource.",
+				Type:        proto.ColumnType_INT,
+				Hydrate:     getBerry,
+				Transform:   transform.FromGo(),
+			},
+			{
+				Name:        "item",
+				Description: "Berries are actually items. This is a reference to the item specific data for this berry.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getBerry,
+			},
+			{
+				Name:        "max_harvest",
+				Description: "The maximum number of these berries that can grow on one tree in Generation IV.",
+				Type:        proto.ColumnType_INT,
+				Hydrate:     getBerry,
+			},
+			{
+				Name:        "natural_gift_power",
+				Description: "The power of the move 'Natural Gift' when used with this Berry.",
+				Type:        proto.ColumnType_INT,
+				Hydrate:     getBerry,
+			},
+			{
+				Name:        "natural_gift_type",
+				Description: "The type inherited by 'Natural Gift' when used with this Berry.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getBerry,
+			},
+			{
+				Name:        "size",
+				Description: "The size of this Berry, in millimeters.",
+				Type:        proto.ColumnType_INT,
+				Hydrate:     getBerry,
+			},
+			{
+				Name:        "smoothness",
+				Description: "The smoothness of this Berry, used in making Pokéblocks or Poffins.",
+				Type:        proto.ColumnType_INT,
+				Hydrate:     getBerry,
+			},
+			{
+				Name:        "soil_dryness",
+				Description: "The speed at which this Berry dries out the soil as it grows. A higher rate means the soil dries more quickly.",
+				Type:        proto.ColumnType_INT,
+				Hydrate:     getBerry,
+			},
+
+			// Standard columns
+			{
+				Name:        "title",
+				Description: "Title of the resource.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+			},
+		},
+	}
+}
+
+func listBerry(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("listBerry")
+
+	offset := 0
+
+	for true {
+		resources, err := pokeapi.Resource("berry", offset)
+
+		if err != nil {
+			plugin.Logger(ctx).Error("pokemon_berry.listBerry", "query_error", err)
+			return nil, err
+		}
+
+		for _, berry := range resources.Results {
+			d.StreamListItem(ctx, berry)
+		}
+
+		// No next URL returned
+		if len(resources.Next) == 0 {
+			break
+		}
+
+		urlOffset, err := extractUrlOffset(resources.Next)
+		if err != nil {
+			plugin.Logger(ctx).Error("pokemon_berry.listBerry", "extract_url_offset_error", err)
+			return nil, err
+		}
+
+		// Set next offset
+		offset = urlOffset
+	}
+
+	return nil, nil
+}
+
+func getBerry(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("getBerry")
+
+	var name string
+
+	if h.Item != nil {
+		result := h.Item.(structs.Result)
+		name = result.Name
+	} else {
+		name = d.KeyColumnQuals["name"].GetStringValue()
+	}
+
+	logger.Debug("Name", name)
+
+	berry, err := pokeapi.Berry(name)
+
+	if err != nil {
+		plugin.Logger(ctx).Error("pokemon_berry.pokemonGet", "query_error", err)
+		return nil, err
+	}
+
+	return berry, nil
+}


### PR DESCRIPTION
Create pokemon-berry table

# Example query results
<details>
  <summary>Results</summary>
  
```
arnab@turbotindias-MacBook-Pro steampipe-plugin-pokemon % steampipe query
Welcome to Steampipe v0.7.1
For more information, type .help
> select
  name,
  id, 
  growth_time,
  max_harvest,
  natural_gift_power,
  size,
  smoothness,
  soil_dryness
from 
  pokemon_berry
+--------+----+-------------+-------------+--------------------+------+------------+--------------+
| name   | id | growth_time | max_harvest | natural_gift_power | size | smoothness | soil_dryness |
+--------+----+-------------+-------------+--------------------+------+------------+--------------+
| aguav  | 14 | 5           | 5           | 60                 | 64   | 25         | 10           |
| razz   | 16 | 2           | 10          | 60                 | 120  | 20         | 35           |
| mago   | 13 | 5           | 5           | 60                 | 126  | 25         | 10           |
| wiki   | 12 | 5           | 5           | 60                 | 115  | 25         | 10           |
| rawst  | 4  | 3           | 5           | 60                 | 32   | 25         | 15           |
| chesto | 2  | 3           | 5           | 60                 | 80   | 25         | 15           |
| pinap  | 20 | 2           | 10          | 70                 | 80   | 20         | 35           |
| leppa  | 6  | 4           | 5           | 60                 | 28   | 20         | 15           |
| pecha  | 3  | 3           | 5           | 60                 | 40   | 25         | 15           |
| persim | 8  | 4           | 5           | 60                 | 47   | 20         | 15           |
| bluk   | 17 | 2           | 10          | 70                 | 108  | 20         | 35           |
| nanab  | 18 | 2           | 10          | 70                 | 77   | 20         | 35           |
| cheri  | 1  | 3           | 5           | 60                 | 20   | 25         | 15           |
| figy   | 11 | 5           | 5           | 60                 | 100  | 25         | 10           |


> select
  name,
  id,
  size
from
  pokemon_berry
where
  size > 100
+--------+----+------+
| name   | id | size |
+--------+----+------+
| razz   | 16 | 120  |
| mago   | 13 | 126  |
| wiki   | 12 | 115  |
| bluk   | 17 | 108  |
| iapapa | 15 | 223  |
| hondew | 24 | 162  |
| watmel | 33 | 250  |
| magost | 28 | 140  |
| pamtre | 32 | 244  |
| rindo  | 39 | 156  |
| grepa  | 25 | 149  |
| rabuta | 29 | 226  |
| qualot | 23 | 110  |
| durin  | 34 | 280  |
| pomeg  | 21 | 135  |
| yache  | 40 | 135  |
| kelpsy | 22 | 150  |
| wacan  | 38 | 250  |
| belue  | 35 | 300  |
| nomel  | 30 | 285  |
| spelon | 31 | 133  |
| tamato | 26 | 200  |
| payapa | 45 | 252  |
| babiri | 51 | 265  |
| petaya | 56 | 237  |
| starf  | 59 | 153  |
| coba   | 44 | 278  |
| enigma | 60 | 155  |
| kasib  | 48 | 144  |
| liechi | 53 | 111  |
| custap | 62 | 267  |
+--------+----+------+


> select
  name,
  id,
  soil_dryness
from
  pokemon_berry
where 
  soil_dryness between 10 and 30
+--------+----+--------------+
| name   | id | soil_dryness |
+--------+----+--------------+
| aguav  | 14 | 10           |
| mago   | 13 | 10           |
| wiki   | 12 | 10           |
| rawst  | 4  | 15           |
| chesto | 2  | 15           |
| leppa  | 6  | 15           |
| pecha  | 3  | 15           |
| persim | 8  | 15           |
| cheri  | 1  | 15           |
| figy   | 11 | 10           |
| iapapa | 15 | 10           |
| oran   | 7  | 15           |
| aspear | 5  | 15           |
| magost | 28 | 10           |
| rabuta | 29 | 10           |
| cornn  | 27 | 10           |
| nomel  | 30 | 10           |
+--------+----+--------------+

```
</details>
