### PR TITLE
Pin actions to commit SHAs

### DIFF
--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -154,7 +154,7 @@ jobs:
           echo "PLUGIN_NAME=${plugin_name}" >> $GITHUB_ENV
 
       # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@v0.2.0
+      - uses: google-github-actions/setup-gcloud@94337306dda8fbd5b65e39ffb810e67e57163f28 # v0.2.0
         with:
           service_account_key: ${{ secrets.STEAMPIPE_REGISTRY_SA_KEY }}
           project_id: ${{ env.PROJECT_ID }}
@@ -278,7 +278,7 @@ jobs:
           echo "PLUGIN_NAME=${plugin_name}" >> $GITHUB_ENV
 
       # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@v0.2.0
+      - uses: google-github-actions/setup-gcloud@94337306dda8fbd5b65e39ffb810e67e57163f28 # v0.2.0
         with:
           service_account_key: ${{ secrets.STEAMPIPE_REGISTRY_SA_KEY }}
           project_id: ${{ env.PROJECT_ID }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -14,8 +14,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: micnncim/action-label-syncer@v1
+      - uses: actions/checkout@ee0669bd1cc54295c7f572d5cc917dfe471480e8 # v2
+      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- Pin remaining unpinned action references to immutable commit SHAs for supply-chain security.

### Actions pinned
- `actions/checkout@v2` -> `ee0669bd1cc54295c7f572d5cc917dfe471480e8`
- `micnncim/action-label-syncer@v1` -> `3abd5ab72fda571e69fffd97bd4e0033dd5f495c`

### Intentionally left unpinned
- `google-github-actions/setup-gcloud@v0.2.0` in `registry-publish.yml` -- very old version; skipping SHA pin for now.